### PR TITLE
Add org event bridge

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,44 @@
+
+resource "aws_cloudwatch_event_permission" "OrganizationAccess" {
+  count        = var.is_hub ? 1 : 0
+  principal    = "*"
+  statement_id = "OrganizationAccess"
+
+  condition {
+    key   = "aws:PrincipalOrgID"
+    type  = "StringEquals"
+    value = var.grace_dev_org_id
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "zone_association" {
+  count         = var.is_hub ? 0 : 1
+  name          = "hosted-zone-association-events"
+  description   = "Capture hosted zone VPC association authorizations"
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.route53"
+  ],
+  "detail-type": [
+    "AWS API Call via CloudTrail"
+  ],
+  "detail": {
+    "eventSource": [
+      "route53.amazonaws.com"
+    ],
+    "eventName": [
+      "CreateVPCAssociationAuthorization"
+    ]
+  }
+}
+PATTERN
+
+}
+
+resource "aws_cloudwatch_event_target" "grace-mgmt-event" {
+  count     = var.is_hub ? 0 : 1
+  rule      = aws_cloudwatch_event_rule.zone_association[0].name
+  target_id = "grace-management-account-eventbus"
+  arn       = "arn:aws:events:us-east-1:${var.mgmt_dev_account}:event-bus/default"
+}

--- a/dns_hub.tf
+++ b/dns_hub.tf
@@ -109,12 +109,15 @@ resource "aws_route53_resolver_endpoint" "external" {
   }
 }
 
+# removes resolve self rule for the DNS HUB
+/* 
 resource "aws_route53_resolver_rule" "hub_local" {
   count       = var.is_hub ? 1 : 0
   domain_name = var.internal_domain
   name        = "resolve-self"
   rule_type   = "SYSTEM"
 }
+*/
 
 resource "aws_route53_resolver_rule" "forward_external" {
   count                = var.is_hub ? 1 : 0
@@ -150,11 +153,14 @@ resource "aws_route53_resolver_rule" "forward_internal" {
 
 # Attach resolver rules to all VPCs in the hub
 
+# Remove attachment of hub_local rule
+/*
 resource "aws_route53_resolver_rule_association" "hub_local" {
   count            = var.is_hub ? length(var.vpc_cidrblocks) : 0
   resolver_rule_id = aws_route53_resolver_rule.hub_local[0].id
   vpc_id           = aws_vpc.self[count.index].id
 }
+*/
 
 resource "aws_route53_resolver_rule_association" "hub_external" {
   count            = var.is_hub ? length(var.vpc_cidrblocks) : 0

--- a/variables.tf
+++ b/variables.tf
@@ -57,3 +57,15 @@ variable "internal" {
   type        = bool
   default     = true
 }
+
+variable "mgmt_dev_account" {
+  description = "GRACE Management AWS account ID"
+  type        = string
+  default     = "671263857155"
+}
+
+variable "grace_dev_org_id" {
+  description = "GRACE Development AWS Org ID"
+  type        = string
+  default     = "o-xgfcwz3555"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -61,11 +61,9 @@ variable "internal" {
 variable "mgmt_dev_account" {
   description = "GRACE Management AWS account ID"
   type        = string
-  default     = "671263857155"
 }
 
 variable "grace_dev_org_id" {
   description = "GRACE Development AWS Org ID"
   type        = string
-  default     = "o-xgfcwz3555"
 }


### PR DESCRIPTION
Adds the following hub side resources:
 - event bridge permission for GRACE Dev AWS Org Accounts

Adds the following spoke side resources:
 - event rule for capturing "CreateVPCAssociationAuthorization" actions
 - event rule target sending to GRACE Dev Mgmt Account's Event Bus

NOTE: also removes the hub_local resolver rule association from the hub VPCs
 